### PR TITLE
Fix answer index for multiples question

### DIFF
--- a/quiz.js
+++ b/quiz.js
@@ -47,6 +47,6 @@ const quiz = [
     {
       question: "1〜100までの整数のうち、3の倍数でも5の倍数でもある数はいくつ？",
       choices: ["6個", "7個", "10個", "13個"],
-      answerIndex: 2
+      answerIndex: 0
     }
   ];


### PR DESCRIPTION
## Summary
- correct the `answerIndex` for the question about multiples of 3 and 5 so that "6個" is selected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842b2d4ca848332b59c2f4f4aa7e4f0