### PR TITLE
Fix duplicate styles for answer results

### DIFF
--- a/style.css
+++ b/style.css
@@ -199,13 +199,4 @@ body {
   .step-dot.active {
     background: #007bff;
   }
-  #answer-result.correct {
-    color: green;
-    font-weight: bold;
-  }
-  
-  #answer-result.incorrect {
-    color: red;
-    font-weight: bold;
-  }
   


### PR DESCRIPTION
## Summary
- cleanup `#answer-result` CSS by removing duplicate style blocks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842b2e08b308332ba836e8427a3eb13